### PR TITLE
fix(bump): Bumps to 0.0.38

### DIFF
--- a/Formula/onegrep-cli.rb
+++ b/Formula/onegrep-cli.rb
@@ -1,7 +1,7 @@
 require "language/node"
 
-VERSION = "0.0.37"
-SHA = "fcbc67b9faba799ccbb8e02db4b1338e184d977f033654cc3ec94632e71662a9"
+VERSION = "0.0.38"
+SHA = "6f9c38ed5ffe1493f1c4fdfd250abaf0e4d1fc2cfe039d2c641920c29a9d9181"
 
 class OnegrepCli < Formula
   repo_name = "onegrep/homebrew-tap"

--- a/Formula/toolprint.rb
+++ b/Formula/toolprint.rb
@@ -1,13 +1,13 @@
 require "language/node"
 
-VERSION = "0.0.37"
-SHA = "fcbc67b9faba799ccbb8e02db4b1338e184d977f033654cc3ec94632e71662a9"
+VERSION = "0.0.38"
+SHA = "6f9c38ed5ffe1493f1c4fdfd250abaf0e4d1fc2cfe039d2c641920c29a9d9181"
 # SHORT_BIN = "tp-cli"
 LONG_BIN = "toolprint"
 
 class Toolprint < Formula
   repo_name = "toolprint/homebrew-tap"
-  formula_name = "tp-cli"
+  formula_name = "toolprint"
   
   desc "Toolprint CLI: Discover, search, and manage tools for your agents."
   homepage "https://www.npmjs.com/package/@onegrep/cli"
@@ -17,7 +17,6 @@ class Toolprint < Formula
   version VERSION
   url "https://registry.npmjs.org/#{package_name}/-/cli-#{version}.tgz"
   sha256 SHA
-  binary_name = "cli"
 
   livecheck do
     url "https://registry.npmjs.org/#{package_name}/latest"
@@ -65,7 +64,7 @@ class Toolprint < Formula
   end
 
   test do
-    system "#{bin}/#{binary_name}", "-V"
-    assert_match version.to_s, shell_output("#{bin}/#{binary_name} -V")
+    system "#{bin}/#{LONG_BIN}", "-V"
+    assert_match version.to_s, shell_output("#{bin}/#{LONG_BIN} -V")
   end
 end

--- a/update-version.sh
+++ b/update-version.sh
@@ -17,7 +17,7 @@ curl -s "$TARBALL_URL" -o "$TARBALL_PATH"
 NEW_SHA=$(shasum -a 256 "$TARBALL_PATH" | cut -d' ' -f1)
 
 # Update all CLI formula files
-for formula_file in "$FORMULA_DIR"/*-cli.rb; do
+for formula_file in "$FORMULA_DIR"/*.rb; do
     echo "Updating $formula_file..."
     sed -i '' "s/VERSION = \"[0-9.]*\"/VERSION = \"$LATEST_VERSION\"/" "$formula_file"
     sed -i '' "s/SHA = \"[a-f0-9]*\"/SHA = \"$NEW_SHA\"/" "$formula_file"


### PR DESCRIPTION
## Description
- Fixes bug with linking the `toolprint` cmd to bin.
- Updates to cli `0.0.38`

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Formula version update
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe)


## Checklist
- [x] I have updated the documentation accordingly
- [x] I have tried linking the tap locally and running it.