### PR TITLE
chore(release): points formula at latest 0.1.0 cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ build-iPhoneSimulator/
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+
+.vite
+.cursor

--- a/Formula/toolprint.rb
+++ b/Formula/toolprint.rb
@@ -1,7 +1,7 @@
 require "language/node"
 
-VERSION = "0.0.48"
-SHA = "66f0681a366b8dc6a099a17aba92484f7642c9617d201a388098b94bd2106892"
+VERSION = "0.1.0"
+SHA = "5601000cc204a9df824ba370927ec0300bcbdd9e52fd9e39a9edeb63ec42f6f2"
 # SHORT_BIN = "tp-cli"
 LONG_BIN = "toolprint"
 


### PR DESCRIPTION
## Description
Formula update to point at `0.1.0` CLI.

## Type of change
- [x] Formula version update
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe)


## Checklist
- [x] I have updated the documentation accordingly
- [x] I have tried linking the tap locally and running it.